### PR TITLE
Adding multi-window option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.8] - 2025-05-27
+
+### Added
+* Implemented `lookback_strategy` in `dist_enum`
+* Use option `immediate_lookback` to search for the pre dates immediatelly before the `post_date`
+* Use option `multi_window` to search for pre dates as windows defined by `max_pre_imgs_per_burst_mw` and `delta_lookback_days_mw` 
+
+
 ## [0.0.7] - 2025-01-16
 
 ### Fixed

--- a/src/dist_s1_enumerator/dist_enum.py
+++ b/src/dist_s1_enumerator/dist_enum.py
@@ -13,7 +13,7 @@ def enumerate_one_dist_s1_product(
     mgrs_tile_id: str,
     track_number: int | list[int],
     post_date: datetime | pd.Timestamp | str,
-    lookback_strategy: str = 'multi_window',
+    lookback_strategy: str = 'immediate_lookback',
     post_date_buffer_days: int = 1,
     max_pre_imgs_per_burst: int = 10,
     max_pre_imgs_per_burst_mw: list[int] = [5, 5],
@@ -183,7 +183,7 @@ def enumerate_one_dist_s1_product(
 def enumerate_dist_s1_products(
     df_rtc_ts: gpd.GeoDataFrame,
     mgrs_tile_ids: list[str],
-    lookback_strategy: str = 'multi_window',
+    lookback_strategy: str = 'immediate_lookback',
     max_pre_imgs_per_burst: int = 10,
     max_pre_imgs_per_burst_mw: list[int] = [5, 5],
     min_pre_imgs_per_burst: int = 2,


### PR DESCRIPTION
Implemented `lookback_strategy` in `dist_enum`
* Use option `immediate_lookback` to search for the pre dates immediatelly before the `post_date`
* Use option `multi_window` to search for pre dates as windows defined by `max_pre_imgs_per_burst_mw` and `delta_lookback_days_mw