### PR TITLE
Fix pandera imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2025-06-06
+
+### Fixed
+- Pandera imports are changing and currently raising lots of warnings. We resolve these warnings.
+
 ## [0.0.8] - 2025-05-27
 
 ### Added

--- a/src/dist_s1_enumerator/asf.py
+++ b/src/dist_s1_enumerator/asf.py
@@ -4,7 +4,7 @@ from warnings import warn
 import asf_search as asf
 import geopandas as gpd
 import pandas as pd
-from pandera import check_input
+from pandera.pandas import check_input
 from rasterio.crs import CRS
 from shapely.geometry import shape
 

--- a/src/dist_s1_enumerator/data_models.py
+++ b/src/dist_s1_enumerator/data_models.py
@@ -1,6 +1,6 @@
 import geopandas as gpd
-from pandera.pandas import Column, DataFrameSchema
 from pandera.engines.pandas_engine import DateTime
+from pandera.pandas import Column, DataFrameSchema
 
 
 burst_schema = DataFrameSchema(

--- a/src/dist_s1_enumerator/data_models.py
+++ b/src/dist_s1_enumerator/data_models.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-from pandera import Column, DataFrameSchema
+from pandera.pandas import Column, DataFrameSchema
 from pandera.engines.pandas_engine import DateTime
 
 

--- a/src/dist_s1_enumerator/dist_enum.py
+++ b/src/dist_s1_enumerator/dist_enum.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import geopandas as gpd
 import pandas as pd
-from pandera import check_input
+from pandera.pandas import check_input
 from tqdm.auto import tqdm
 
 from dist_s1_enumerator.asf import get_rtc_s1_metadata_from_acq_group

--- a/src/dist_s1_enumerator/rtc_s1_io.py
+++ b/src/dist_s1_enumerator/rtc_s1_io.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import backoff
 import geopandas as gpd
 import requests
-from pandera import check_input
+from pandera.pandas import check_input
 from rasterio.errors import RasterioIOError
 from requests.exceptions import HTTPError
 from tqdm.auto import tqdm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,11 @@
 import os
 from collections.abc import Callable, Generator
-from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
 
-@contextmanager
-@pytest.fixture
+@pytest.fixture(scope='session')
 def change_local_dir() -> Generator[Callable[[Path], Path], None, None]:
     """Fixture to temporarily change the working directory."""
     original_dir = Path.cwd()
@@ -24,7 +22,7 @@ def change_local_dir() -> Generator[Callable[[Path], Path], None, None]:
     assert Path.cwd() == original_dir
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def test_dir() -> Path:
     """Fixture to provide the path to the test directory."""
     test_dir = Path(__file__).parent

--- a/tests/test_dist_enum.py
+++ b/tests/test_dist_enum.py
@@ -5,7 +5,7 @@ import geopandas as gpd
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
-from pandera import check_input
+from pandera.pandas import check_input
 from pytest_mock import MockerFixture
 
 from dist_s1_enumerator.data_models import rtc_s1_resp_schema, rtc_s1_schema


### PR DESCRIPTION
We get these warnings:

```
/opt/conda/envs/dist-s1-env/lib/python3.13/site-packages/pandera/_pandas_deprecated.py:146: FutureWarning: Importing pandas-specific classes and functions from the
top-level pandera module will be **removed in a future version of pandera**.
If you're using pandera to validate pandas objects, we highly recommend updating
your import:

# old import
import pandera as pa

# new import
import pandera.pandas as pa

If you're using pandera to validate objects from other compatible libraries
like pyspark or polars, see the supported libraries section of the documentation
for more information on how to import pandera:

https://pandera.readthedocs.io/en/stable/supported_libraries.html

To disable this warning, set the environment variable:

export DISABLE_PANDERA_IMPORT_WARNING=True
```