### PR TITLE
Some better prints/tqdm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-08-07
+
+### Added
+* Improved tqdm outputs for enumeration of 1 dist-s1 product with multiwindow
+* Added back more print statements
+
 ## [1.0.0] - 2025-08-05
 
 ### Changed


### PR DESCRIPTION
I removed Talib's print statements, but for multi-window metadata searching, it's important to know things are working.

At some point, we should improve the speed of the enumeration of 1 product (i.e. hit the DAAC once).